### PR TITLE
fix link to absolute so it resolves

### DIFF
--- a/CONTRIBUTING-example.md
+++ b/CONTRIBUTING-example.md
@@ -2,7 +2,7 @@
 
 Thanks for contributing! Here are few useful things to know before submitting your Pull Request.
 
-* Licensing - see [LICENSE.txt](LICENSE.txt)
+* Licensing - see [LICENSE.txt](/LICENSE.txt)
 * [Setting up your environment](#setting-up-your-environment)
 * [Markup](#markup)
     * _SUMMARY.md


### PR DESCRIPTION
This link is missing a leading / so it resolves to the LICENSE.txt in the root of the intellij-sdk-docs, where this repo is a submodule.
