### PR TITLE
fix submodule link to https:// absolute, otherwise GitHub won't resolve

### DIFF
--- a/CONTRIBUTING-example.md
+++ b/CONTRIBUTING-example.md
@@ -2,7 +2,7 @@
 
 Thanks for contributing! Here are few useful things to know before submitting your Pull Request.
 
-* Licensing - see [LICENSE.txt](/LICENSE.txt)
+* Licensing - see [LICENSE.txt](https://github.com/vsch/intellij-sdk-docs/blob/master/LICENSE.txt)
 * [Setting up your environment](#setting-up-your-environment)
 * [Markup](#markup)
     * _SUMMARY.md


### PR DESCRIPTION
My bad, previous fix makes it absolute, but being a submodule, absolute / means relative to module/blob/master not the main repo blob/master. Now fixed. I'll have to add an inspection for that.
